### PR TITLE
Upgrade ip-range-check

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "mocha": "^2.2.4"
   },
   "dependencies": {
-    "ip-range-check": "0.0.1"
+    "ip-range-check": "0.0.2"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
ip-range-check@0.0.1 had a `debugger` statement that is very annoying when attempting to debug.
